### PR TITLE
[Ruby] Alinhamento de parâmetros

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -63,3 +63,6 @@ Bundler/OrderedGems:
 
 Layout/MultilineMethodCallIndentation:
   Enabled: false
+
+Layout/AlignParameters:
+  EnforcedStyle: with_fixed_indentation


### PR DESCRIPTION
Aplica regra para alinhamento de parâmetros com indentação fixa em vez de orientada ao primeiro parâmetro:

http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Layout/AlignParameters

```ruby
# good

foo :bar,
  :baz

# bad

foo :bar,
    :baz
```

Meu argumento é que a indentação fica confusa quando alinhada no primeiro parâmetro, ainda mais se o número de espaços for ímpar.