### PR TITLE
[Ruby] Keywords para contexto do rspec

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -56,6 +56,11 @@ Style/AsciiComments:
 Style/Lambda:
   EnforcedStyle: literal
 
+# RSPEC #######################################################################
+
+RSpec/ContextWording:
+  Enabled: false
+
 # OUTROS ######################################################################
 
 Bundler/OrderedGems:


### PR DESCRIPTION
Por padrão, o rubocop-rspec verifica pelas keywords `when|with|without` no bloco `context`. Como nossas specs são escritas em [português](https://github.com/vindi/camara/blob/master/CONTENT.md#português), isso não se aplica.

https://github.com/backus/rubocop-rspec/blob/master/config/default.yml

Pensei em incluir uma lista de palavras em português (usando, com, sem, quando, etc), mas não consegui elaborar uma lista objetiva. Por este motivo prefiro sugerir a desativação do cop.