### PR TITLE
Desativando Style/GuardClause

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -56,6 +56,9 @@ Style/AsciiComments:
 Style/Lambda:
   EnforcedStyle: literal
 
+Style/GuardClause:
+  Enabled: false
+
 # RSPEC #######################################################################
 
 RSpec/ContextWording:


### PR DESCRIPTION
## Motivação

Estamos esbarrando com frequência no cop `Style/GuardClause` que indica a seguinte refatoração:

```ruby
# bad
def method
  if check?
    "a"
  end
end

# good
def method
  "a" if check?
end
```
Essa regra é legal, mas o problema de forçar via Rubocop é que às vezes essa linha no format "guard" fica maior que 80 caracteres, esbarrando na outra verificação.

## Solução proposta

Recomendo desativar o cop, mas reforço que não estou desencorajando a técnica do guard clause.