### PR TITLE
Aumentar o limite de colunas para 100

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -40,7 +40,7 @@ Metrics/ModuleLength:
   Max: 250
 
 Metrics/LineLength:
-  Max: 120
+  Max: 100
 
 # STYLES ######################################################################
 

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -39,6 +39,9 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   Max: 250
 
+Metrics/LineLength:
+  Max: 120
+
 # STYLES ######################################################################
 
 Style/FrozenStringLiteralComment:


### PR DESCRIPTION
## Motivação
A adoção de limitar o código em no máximo 80 colunas aconteceu em grande parte por causa da resolução dos monitores da época.

Vejo que não faz mais sentido pela resolução dos monitores atuais.
Post que encontrei sobre o assunto e achei interessante: https://hackernoon.com/does-column-width-of-80-make-sense-in-2018-50c161fbdcf6

## Solução proposta
Aumentar o limite para 120 colunas.