### PR TITLE
Alterações iniciais para reek

### DIFF
--- a/.defaults.reek
+++ b/.defaults.reek
@@ -1,40 +1,58 @@
 ---
-TooManyStatements:
-  max_statements: 10
-UncommunicativeMethodName:
-  reject:
-  - !ruby/regexp /^[a-z]$/
-  - !ruby/regexp /[0-9]$/
-UncommunicativeParameterName:
-  reject:
-  - !ruby/regexp /^.$/
-  - !ruby/regexp /[0-9]$/
-  - !ruby/regexp /^_/
-UncommunicativeVariableName:
-  reject:
-  - !ruby/regexp /^.$/
-  - !ruby/regexp /[0-9]$/
-UtilityFunction:
-  enabled: false
-LongParameterList:
-  enabled: false
-DuplicateMethodCall:
-  max_calls: 2
-IrresponsibleModule:
-  enabled: false
-NestedIterators:
-  max_allowed_nesting: 2
-PrimaDonnaMethod:
-  enabled: false
-UnusedParameters:
-  enabled: false
-FeatureEnvy:
-  enabled: false
-ControlParameter:
-  enabled: false
-UnusedPrivateMethod:
-  enabled: false
-InstanceVariableAssumption:
-  exclude:
-    - !ruby/regexp /Controller$/
-    - !ruby/regexp /Mailer$/
+detectors:
+  NilCheck:
+    enabled: false
+  MissingSafeMethod:
+    enabled: false
+  TooManyStatements:
+    max_statements: 10
+  UncommunicativeMethodName:
+    reject:
+      - "/^[a-z]$/"
+      - "/[0-9]$/"
+  UncommunicativeParameterName:
+    reject:
+      - "/^.$/"
+      - "/[0-9]$/"
+      - "/^_/"
+  UncommunicativeVariableName:
+    reject:
+      - "/^.$/"
+      - "/[0-9]$/"
+  UtilityFunction:
+    enabled: false
+  LongParameterList:
+    enabled: false
+  DuplicateMethodCall:
+    max_calls: 2
+  IrresponsibleModule:
+    enabled: false
+  NestedIterators:
+    max_allowed_nesting: 2
+  UnusedParameters:
+    enabled: false
+  FeatureEnvy:
+    enabled: false
+  ControlParameter:
+    enabled: false
+  UnusedPrivateMethod:
+    enabled: false
+
+directories:
+  "app/controllers":
+    IrresponsibleModule:
+      enabled: false
+    InstanceVariableAssumption:
+      enabled: false
+  "app/helpers":
+    IrresponsibleModule:
+      enabled: false
+  "app/mailers":
+    InstanceVariableAssumption:
+      enabled: false
+  "app/models":
+    InstanceVariableAssumption:
+      enabled: false
+  "app/services":
+    Attribute:
+      enabled: false

--- a/.defaults.reek
+++ b/.defaults.reek
@@ -15,6 +15,9 @@ detectors:
       - "/^.$/"
       - "/[0-9]$/"
       - "/^_/"
+  UncommunicativeModuleName:
+    accept:
+      - "^API::V1.*$"
   UncommunicativeVariableName:
     reject:
       - "/^.$/"

--- a/.defaults.reek
+++ b/.defaults.reek
@@ -53,6 +53,3 @@ directories:
   "app/models":
     InstanceVariableAssumption:
       enabled: false
-  "app/services":
-    Attribute:
-      enabled: false

--- a/.defaults.reek
+++ b/.defaults.reek
@@ -39,7 +39,7 @@ detectors:
   ControlParameter:
     enabled: false
   UnusedPrivateMethod:
-    enabled: false
+    enabled: true
 
 directories:
   "app/controllers":

--- a/.defaults.reek
+++ b/.defaults.reek
@@ -5,7 +5,7 @@ detectors:
   MissingSafeMethod:
     enabled: false
   TooManyStatements:
-    max_statements: 10
+    max_statements: 6
   UncommunicativeMethodName:
     reject:
       - "/^[a-z]$/"
@@ -25,7 +25,7 @@ detectors:
   UtilityFunction:
     enabled: false
   LongParameterList:
-    enabled: false
+    enabled: true
   DuplicateMethodCall:
     max_calls: 2
   IrresponsibleModule:
@@ -43,12 +43,7 @@ detectors:
 
 directories:
   "app/controllers":
-    IrresponsibleModule:
-      enabled: false
     InstanceVariableAssumption:
-      enabled: false
-  "app/helpers":
-    IrresponsibleModule:
       enabled: false
   "app/mailers":
     InstanceVariableAssumption:


### PR DESCRIPTION
# Motivação

Percebemos que o `NilCheck` é um code smell bem pervasivo e, por enquanto, não temos como nos livrar dele. Além disso, checaram-se outros detectors.

# Solução proposta

1. [Alterar](https://github.com/troessner/reek/blob/master/docs/Missing-Safe-Method.md) `PrimaDonnaMethod` para `MissingSafeMethod`: `Missing Safe Method was formerly known as Prima Donna Method.`;

2. Não utilizar mais regexp no yml; o reek na linha de comando recusa-se a rodar com o `defaults.reek` do repositório;

3. Adicionar diretórios de Rails como na [documentação do reek](https://github.com/troessner/reek#working-with-rails); remover as diretivas que já constam como `false` nas principais.

4. Em `UncommunicativeModuleName`, [permitir](https://github.com/troessner/reek/blob/v5.2.0/docs/Uncommunicative-Module-Name.md) o valor `API::V1::*`.

# Como testar

`gem install reek`

`$ reek -c (arquivodeconfiguracao) (diretóriodoprojeto)/app`

Deve mostrar os code smells pendentes.