### PR TITLE
Conversão do csslintrc anterior para o padrão especificado na documentação

### DIFF
--- a/.csslintrc
+++ b/.csslintrc
@@ -1,2 +1,9 @@
---exclude-exts=.min.css
---ignore=adjoining-classes,box-model,ids,order-alphabetical,unqualified-attributes
+{
+  "ignore": [
+    "adjoining-classes",
+    "box-model",
+    "ids",
+    "order-alphabetical",
+    "unqualified-attributes"
+  ]
+}


### PR DESCRIPTION
# Motivação

Nos erros de csslint do ebert, parece que o `.csslintrc` não está sendo corretamente aplicado; vemos erros que deveriam ser ignorados sendo mostrados no ebert. [Exemplo](https://ebertapp.io/github/vindi/recurrent/reviews/81/lang:css?page=9):

`Adjoining classes: .carousel-inner > .next.left`

(este erro deveria ser ignorado)

# Solução proposta

Por enquanto, testar o `.csslintrc` com o arquivo convertido. Notar que no `.csslintrc` não é possível excluir `min.css` (esta função é da linha de comando exclusivamente), pode ser que o `ebert` já exclua estes arquivos.

Ao mesmo tempo: perguntar ao George qual a versão de todos os linters, se possível.