### PR TITLE
Configuração básica: eslint

### DIFF
--- a/.defaults.reek
+++ b/.defaults.reek
@@ -1,40 +1,58 @@
 ---
-TooManyStatements:
-  max_statements: 10
-UncommunicativeMethodName:
-  reject:
-  - !ruby/regexp /^[a-z]$/
-  - !ruby/regexp /[0-9]$/
-UncommunicativeParameterName:
-  reject:
-  - !ruby/regexp /^.$/
-  - !ruby/regexp /[0-9]$/
-  - !ruby/regexp /^_/
-UncommunicativeVariableName:
-  reject:
-  - !ruby/regexp /^.$/
-  - !ruby/regexp /[0-9]$/
-UtilityFunction:
-  enabled: false
-LongParameterList:
-  enabled: false
-DuplicateMethodCall:
-  max_calls: 2
-IrresponsibleModule:
-  enabled: false
-NestedIterators:
-  max_allowed_nesting: 2
-PrimaDonnaMethod:
-  enabled: false
-UnusedParameters:
-  enabled: false
-FeatureEnvy:
-  enabled: false
-ControlParameter:
-  enabled: false
-UnusedPrivateMethod:
-  enabled: false
-InstanceVariableAssumption:
-  exclude:
-    - !ruby/regexp /Controller$/
-    - !ruby/regexp /Mailer$/
+detectors:
+  NilCheck:
+    enabled: false
+  MissingSafeMethod:
+    enabled: false
+  TooManyStatements:
+    max_statements: 10
+  UncommunicativeMethodName:
+    reject:
+      - "/^[a-z]$/"
+      - "/[0-9]$/"
+  UncommunicativeParameterName:
+    reject:
+      - "/^.$/"
+      - "/[0-9]$/"
+      - "/^_/"
+  UncommunicativeVariableName:
+    reject:
+      - "/^.$/"
+      - "/[0-9]$/"
+  UtilityFunction:
+    enabled: false
+  LongParameterList:
+    enabled: false
+  DuplicateMethodCall:
+    max_calls: 2
+  IrresponsibleModule:
+    enabled: false
+  NestedIterators:
+    max_allowed_nesting: 2
+  UnusedParameters:
+    enabled: false
+  FeatureEnvy:
+    enabled: false
+  ControlParameter:
+    enabled: false
+  UnusedPrivateMethod:
+    enabled: false
+
+directories:
+  "app/controllers":
+    IrresponsibleModule:
+      enabled: false
+    InstanceVariableAssumption:
+      enabled: false
+  "app/helpers":
+    IrresponsibleModule:
+      enabled: false
+  "app/mailers":
+    InstanceVariableAssumption:
+      enabled: false
+  "app/models":
+    InstanceVariableAssumption:
+      enabled: false
+  "app/services":
+    Attribute:
+      enabled: false

--- a/.defaults.reek
+++ b/.defaults.reek
@@ -15,6 +15,9 @@ detectors:
       - "/^.$/"
       - "/[0-9]$/"
       - "/^_/"
+  UncommunicativeModuleName:
+    accept:
+      - "^API::V1.*$"
   UncommunicativeVariableName:
     reject:
       - "/^.$/"

--- a/.defaults.reek
+++ b/.defaults.reek
@@ -53,6 +53,3 @@ directories:
   "app/models":
     InstanceVariableAssumption:
       enabled: false
-  "app/services":
-    Attribute:
-      enabled: false

--- a/.defaults.reek
+++ b/.defaults.reek
@@ -5,7 +5,7 @@ detectors:
   MissingSafeMethod:
     enabled: false
   TooManyStatements:
-    max_statements: 10
+    max_statements: 6
   UncommunicativeMethodName:
     reject:
       - "/^[a-z]$/"
@@ -25,7 +25,7 @@ detectors:
   UtilityFunction:
     enabled: false
   LongParameterList:
-    enabled: false
+    enabled: true
   DuplicateMethodCall:
     max_calls: 2
   IrresponsibleModule:
@@ -43,12 +43,7 @@ detectors:
 
 directories:
   "app/controllers":
-    IrresponsibleModule:
-      enabled: false
     InstanceVariableAssumption:
-      enabled: false
-  "app/helpers":
-    IrresponsibleModule:
       enabled: false
   "app/mailers":
     InstanceVariableAssumption:

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,9 @@ module.exports = {
     "sourceType": "module"
   },
   "env": {
-    "browser": true
+    "browser": true,
+    "commonjs": true,
+    "jquery": true
   },
   'rules': {
     'camelcase': 2,


### PR DESCRIPTION
# Motivação

O `eslint`, por padrão, não reconhece a existência de `jquery` (indica que `jQuery` ou `$` não estão definidos) nem `commonjs` (segundo a documentação do `eslint`, é para webpack, que pretendemos um dia usar).

# Solução proposta

Incluir, nas exceções do `eslint`, os itens `jquery` e `commonjs`. Documentação na [lista do eslint](https://eslint.org/docs/user-guide/configuring#specifying-environments).
