### PR TITLE
eslint: configuração básica

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,9 @@ module.exports = {
     "sourceType": "module"
   },
   "env": {
-    "browser": true
+    "browser": true,
+    "commonjs": true,
+    "jquery": true
   },
   'rules': {
     'camelcase': 2,


### PR DESCRIPTION
# Motivação

O `eslint`, por padrão, não reconhece a existência de `jquery` (indica que `jQuery` ou `$` não estão definidos) nem `commonjs` (segundo a documentação do `eslint`, é para webpack, que pretendemos um dia usar).

# Solução proposta

Incluir, nas exceções do `eslint`, os itens `jquery` e `commonjs`. Documentação na [lista do eslint](https://eslint.org/docs/user-guide/configuring#specifying-environments).
