### PR TITLE
Adiciona algumas flexibilidades ao cop de rspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,6 +67,9 @@ Style/GuardClause:
 RSpec/ContextWording:
   Enabled: false
 
+RSpec/ExampleLength:
+  Max: 7
+
 RSpec/MultipleExpectations:
   Max: 3
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,6 +67,12 @@ Style/GuardClause:
 RSpec/ContextWording:
   Enabled: false
 
+RSpec/ExampleLength:
+  Max: 10
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
 # OUTROS ######################################################################
 
 Bundler/OrderedGems:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,11 +67,8 @@ Style/GuardClause:
 RSpec/ContextWording:
   Enabled: false
 
-RSpec/ExampleLength:
-  Max: 10
-
 RSpec/MultipleExpectations:
-  Enabled: false
+  Max: 3
 
 # OUTROS ######################################################################
 


### PR DESCRIPTION
## Motivação :muscle: 

Acredito que as regras padrão do rspec-rubocop não satisfazem todas as situações que temos.

## Solução proposta :wrench:

Flexibilizar as regras de:
- quantidade de `expect`'s por bloco `it`
- quantidade de linhas por bloco

Dêem suas opiniões :smiley: 