### PR TITLE
Desliga UnusedPrivateMethod

### DIFF
--- a/.defaults.reek
+++ b/.defaults.reek
@@ -39,7 +39,7 @@ detectors:
   ControlParameter:
     enabled: false
   UnusedPrivateMethod:
-    enabled: true
+    enabled: false
 
 directories:
   "app/controllers":


### PR DESCRIPTION
Estou propondo desligar o `UnusedPrivateMethod` que não consegue verificar se o método está sendo usado pelos callbacks do Rails.

A própria documentação do Reek sugere desligar esse check para apps Rails: https://github.com/troessner/reek#working-with-rails