### PR TITLE
TooManyMethods

### DIFF
--- a/.defaults.reek
+++ b/.defaults.reek
@@ -7,7 +7,7 @@ detectors:
   TooManyStatements:
     max_statements: 6
   TooManyMethods:
-    max_methods: 20
+    max_methods: 30
   UncommunicativeMethodName:
     reject:
       - "/^[a-z]$/"


### PR DESCRIPTION
Estou propondo aumentar a configuração do [`TooManyMethods`](https://github.com/troessner/reek/blob/master/docs/Too-Many-Methods.md) de 15 (valor default) para 30. É um valor meio exagerado, mas factível na minha opinião.

No Recurrent, por exemplo, a configuração `max_methods: 15` encontra 34 warnings. Com `max_methods: 30`, apenas 7.

Meu objetivo é ir aumentando a régua de qualidade aos poucos, porém termos que partir de algum lugar onde isso não seja impraticável. Por exemplo: Na configuração atual, para adicionar um método novo em `Merchant` teremos que refatorar outros 15. Na configuração proposta, apenas duas refatorações seriam necessárias.

O que acham? Prefiro relaxar os linters do que abusar dos comentários para ignorar.