### PR TITLE
Adiciona filtro para BatchHandler::Exporter

### DIFF
--- a/.defaults.reek
+++ b/.defaults.reek
@@ -20,7 +20,7 @@ detectors:
   UncommunicativeModuleName:
     accept:
       - "^API::V1.*$"
-      - "^BatchHandler::Exporter.*$"
+      - "/[0-9]$/"
   UncommunicativeVariableName:
     reject:
       - "/^.$/"

--- a/.defaults.reek
+++ b/.defaults.reek
@@ -20,6 +20,7 @@ detectors:
   UncommunicativeModuleName:
     accept:
       - "^API::V1.*$"
+      - "^BatchHandler::Exporter.*$"
   UncommunicativeVariableName:
     reject:
       - "/^.$/"


### PR DESCRIPTION
## Motivação
Os arquivos de [CNAB](https://pt.wikipedia.org/wiki/Concilia%C3%A7%C3%A3o_banc%C3%A1ria) possuem uma estrutura um pouco diferente do aplicado em alguns padrões **Ruby** | **Rails**.
Isso impacta nos smells do projeto [recurrent](https://github.com/vindi/recurrent) pois impossibilita a adição de novos [CNABs](https://pt.wikipedia.org/wiki/Concilia%C3%A7%C3%A3o_banc%C3%A1ria) e consequentemente a manutenção dos já existentes.

## Solução proposta
Ignorar toda a cadeia de classes do **BatchHandler** no projeto [recurrent](https://github.com/vindi/recurrent)