### PR TITLE
Adiciona melhores práticas com data e hora

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,9 @@ Rails/UnknownEnv:
     - staging
     - sandbox
 
+Rails/Date:
+  Enabled: true
+
 # METRICS #####################################################################
 
 Metrics/AbcSize:


### PR DESCRIPTION
## Motivação
Verifiquei que estamos usando `Date.today` e `Time.parse` em código interno. Isso gera inconsistência com fusos horários e testes quebrados dependendo do horário do dia.

## Solução proposta
Estou propondo habilitar o cop `Rails/Date` do Rubocop para aderir às melhores práticas nan manipulação de data e hora.

Mais informações:
- https://docs.rubocop.org/projects/rails/en/stable/cops_rails/#railsdate
- https://thoughtbot.com/blog/its-about-time-zones

Resumo do artigo acima:

### DON’T USE
```
* Time.now
* Date.today
* Date.today.to_time
* Time.parse("2015-07-04 17:05:37")
* Time.strptime(string, "%Y-%m-%dT%H:%M:%S%z")
```

### DO USE

```
* Time.current
* 2.hours.ago
* Time.zone.today
* Date.current
* 1.day.from_now
* Time.zone.parse("2015-07-04 17:05:37")
* Time.strptime(string, "%Y-%m-%dT%H:%M:%S%z").in_time_zone
```