### PR TITLE
Adiciona regra para o reek ignorar o path `vendor/gems/active_merchant/test`

### DIFF
--- a/.defaults.reek
+++ b/.defaults.reek
@@ -53,3 +53,6 @@ directories:
   "app/models":
     InstanceVariableAssumption:
       enabled: false
+
+exclude_paths:
+  - vendor/gems/active_merchant/test


### PR DESCRIPTION
## Motivação
Temos um PR que está quebrando no CodeClimate, pois ele está  análisando as classes de testes. Chegamos a editar diretamente no arquivo de configuração do `CodeClimate`, porém ainda sim não foi possível solucionar o problema.

## Solução proposta
Basicamente estamos adicionando uma regra no arquivo de configuração do `Reek` para não análisar o path `vendor/gems/active_merchant/test`.

## Observação
Adicionei temporariamente a url do commit no PR do Gateway e o CI passou com sucesso, quando esse PR for mergeado, irei voltar a url da master.
- https://github.com/vindi/gateway/pull/854